### PR TITLE
add Makefile and update README build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+.PHONY: all clean build build-native build-cpu test run release
+
+VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH := $(shell uname -m)
+ifeq ($(ARCH),x86_64)
+	ARCH := amd64
+endif
+ifeq ($(ARCH),aarch64)
+	ARCH := arm64
+endif
+
+all: build
+
+# Build (default features, includes nvidia)
+build:
+	@echo "Building seine..."
+	cargo build --release
+
+# Build with native CPU tuning (no GPU)
+build-native:
+	@echo "Building seine (native CPU, no GPU)..."
+	RUSTFLAGS="-C target-cpu=native" cargo build --profile release-native --no-default-features
+
+# Build CPU-only (no GPU, default tuning)
+build-cpu:
+	@echo "Building seine (CPU only)..."
+	cargo build --release --no-default-features
+
+# Run tests
+test:
+	@echo "Running tests..."
+	cargo test --workspace
+
+# Run after building
+run: build
+	./target/release/seine
+
+# Build release package for current platform
+release: build
+	@echo "Packaging release for $(OS)-$(ARCH)..."
+	@mkdir -p releases
+	@cp target/release/seine releases/seine
+	@cd releases && zip -q seine-$(VERSION)-$(OS)-$(ARCH).zip seine
+ifeq ($(OS),darwin)
+	@cd releases && shasum -a 256 seine-$(VERSION)-$(OS)-$(ARCH).zip >> SHA256SUMS.txt
+else
+	@cd releases && sha256sum seine-$(VERSION)-$(OS)-$(ARCH).zip >> SHA256SUMS.txt
+endif
+	@rm -f releases/seine
+	@echo "Built: releases/seine-$(VERSION)-$(OS)-$(ARCH).zip"
+	@echo "Checksum added to releases/SHA256SUMS.txt"
+
+# Clean build artifacts
+clean:
+	@echo "Cleaning..."
+	cargo clean
+	rm -rf releases/
+
+# Clean miner data
+clean-data:
+	@echo "Removing miner data..."
+	rm -rf data/ seine-data/
+
+# Clean everything
+clean-all: clean clean-data
+
+# Fetch dependencies
+deps:
+	@echo "Fetching Rust dependencies..."
+	cargo fetch

--- a/README.md
+++ b/README.md
@@ -196,6 +196,29 @@ cargo build --release --no-default-features --features metal
 
 ## Building from Source
 
+Requires [Rust](https://rustup.rs/) and GNU Make.
+
+Using Make:
+
+```bash
+# Default build (includes NVIDIA support)
+make
+
+# CPU-only build (no CUDA dependency)
+make build-cpu
+
+# Host-native CPU build (optimized for your specific CPU)
+make build-native
+
+# Run tests
+make test
+
+# Package a release zip for current platform
+make release
+```
+
+Or directly with Cargo:
+
 ```bash
 # Default build (includes NVIDIA support)
 cargo build --release


### PR DESCRIPTION
Add a Makefile with build, test, release, and clean targets. Version is extracted from Cargo.toml to avoid drift. README now documents Make targets alongside direct Cargo commands and lists GNU Make as a build dependency.